### PR TITLE
install.sh: fix - added $ZDOTDIR/.zshrc as possible SHELL_CONFIG path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,8 +45,11 @@ if command -v go >/dev/null 2>&1; then
              echo -e "${BLUE}[INFO] $GOBIN is not in your PATH.${NC}"
              
              SHELL_CONFIG=""
-             SHELL_CONFIGS=("$HOME/.bashrc" "$HOME/.zshrc" "$ZDOTDIR/.zshrc")
-
+             SHELL_CONFIGS=("$HOME/.bashrc" "$HOME/.zshrc")
+             if [ -n "${ZDOTDIR:-}" ]; then
+                 SHELL_CONFIGS+=("$ZDOTDIR/.zshrc")
+             fi
+    
              for CFG in "${SHELL_CONFIGS[@]}"; do
                  if [ -f "$CFG" ]; then
                      SHELL_CONFIG="$CFG"

--- a/install.sh
+++ b/install.sh
@@ -45,11 +45,13 @@ if command -v go >/dev/null 2>&1; then
              echo -e "${BLUE}[INFO] $GOBIN is not in your PATH.${NC}"
              
              SHELL_CONFIG=""
-             if [ -f "$HOME/.bashrc" ]; then
-                 SHELL_CONFIG="$HOME/.bashrc"
-             elif [ -f "$HOME/.zshrc" ]; then
-                 SHELL_CONFIG="$HOME/.zshrc"
-             fi
+             SHELL_CONFIGS=("$HOME/.bashrc" "$HOME/.zshrc" "$ZDOTDIR/.zshrc")
+
+             for CFG in "${SHELL_CONFIGS[@]}"; do
+                 if [ -f "$CFG" ]; then
+                     SHELL_CONFIG="$CFG"
+                 fi
+             done 
 
              if [ -n "$SHELL_CONFIG" ]; then
                  echo -e "${BLUE}[+] detected $SHELL_CONFIG. Appending to PATH...${NC}"

--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,7 @@ if command -v go >/dev/null 2>&1; then
              for CFG in "${SHELL_CONFIGS[@]}"; do
                  if [ -f "$CFG" ]; then
                      SHELL_CONFIG="$CFG"
+                     break
                  fi
              done 
 


### PR DESCRIPTION
Hi! Nice project. 

While running setup I've encountered that it did not detect where my `.zshrc` was located. Zsh has optional environment variable - `$ZDOTDIR` it tells where zsh specific files should be located.

Also I made a simple for loop so in the future it will be simpler to add other shell configuration paths. 