### PR TITLE
Process column width fix

### DIFF
--- a/model.go
+++ b/model.go
@@ -177,6 +177,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tableHeight = 2
 		}
 		m.table.SetHeight(tableHeight)
+		m.updateTableColumns()
 
 	case []PortEntry:
 		m.entries = msg
@@ -229,13 +230,16 @@ func (m *model) sortEntries() {
 }
 
 func (m *model) updateTableColumns() {
+	usedWidth := (8 + 6 + 12 + 8 + 20) + 14
+	remainingWidth := m.width - usedWidth
+
 	columns := []table.Column{
 		{Title: "Port", Width: 8},
 		{Title: "Proto", Width: 6},
 		{Title: "State", Width: 12},
 		{Title: "PID", Width: 8},
 		{Title: "Address", Width: 20},
-		{Title: "Process", Width: 20}, // Flexible
+		{Title: "Process", Width: remainingWidth}, // Flexible
 	}
 
 	// Add arrow indicator


### PR DESCRIPTION
I made the last column in the view have flexible width. I did not come up with some nicer solution rather than just calculated remaining width...

Also `m.updateTableColumns()` will be executed on `tea.WindowSizeMsg` so the las column automatically gets resized with terminal