### PR TITLE
feat: add macOS port discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LazyPorts
 
-> **Visual port manager for Linux**
+> **Visual port manager for Linux and macOS**
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Go](https://img.shields.io/badge/Go-1.24+-00ADD8.svg)
@@ -15,6 +15,8 @@ Built with Bubble Tea and Lipgloss.
 ## Prerequisites
 
 -   **Go 1.24** or higher (required for installation)
+-   **Linux**: `ss` from iproute2
+-   **macOS**: `lsof` (included with macOS)
 
 ## Installation
 

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -29,12 +31,48 @@ var (
 )
 
 func getPorts() ([]PortEntry, error) {
+	if runtime.GOOS == "darwin" {
+		return getDarwinPorts()
+	}
+
 	cmd := exec.Command("ss", "-tulnp")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to run ss: %v", err)
 	}
 
+	return parseSSPorts(string(output)), nil
+}
+
+func getDarwinPorts() ([]PortEntry, error) {
+	tcpOutput, err := lsofOutput("-nP", "-iTCP", "-sTCP:LISTEN")
+	if err != nil {
+		return nil, fmt.Errorf("failed to run lsof for TCP ports: %v", err)
+	}
+
+	udpOutput, err := lsofOutput("-nP", "-iUDP")
+	if err != nil {
+		return nil, fmt.Errorf("failed to run lsof for UDP ports: %v", err)
+	}
+
+	return dedupePorts(parseLSOFPorts(string(tcpOutput) + "\n" + string(udpOutput))), nil
+}
+
+func lsofOutput(args ...string) ([]byte, error) {
+	output, err := exec.Command("lsof", args...).Output()
+	if err == nil {
+		return output, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(output) == 0 {
+		return output, nil
+	}
+
+	return output, err
+}
+
+func parseSSPorts(output string) []PortEntry {
 	lines := strings.Split(string(output), "\n")
 	var entries []PortEntry
 
@@ -105,7 +143,82 @@ func getPorts() ([]PortEntry, error) {
 		})
 	}
 
-	return entries, nil
+	return entries
+}
+
+func parseLSOFPorts(output string) []PortEntry {
+	lines := strings.Split(output, "\n")
+	var entries []PortEntry
+
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 9 || fields[0] == "COMMAND" {
+			continue
+		}
+
+		proto := strings.ToLower(fields[7])
+		if proto != "tcp" && proto != "udp" {
+			continue
+		}
+
+		name := fields[8]
+		if strings.Contains(name, "->") {
+			continue
+		}
+
+		address, port, ok := splitHostPort(name)
+		if !ok || port == "*" {
+			continue
+		}
+
+		state := "LISTEN"
+		if proto == "udp" {
+			state = "UDP"
+		}
+
+		entries = append(entries, PortEntry{
+			Port:     port,
+			Protocol: proto,
+			PID:      fields[1],
+			Process:  strings.ReplaceAll(fields[0], `\x20`, " "),
+			State:    state,
+			Address:  normalizeAddress(address),
+		})
+	}
+
+	return entries
+}
+
+func dedupePorts(entries []PortEntry) []PortEntry {
+	seen := make(map[PortEntry]bool)
+	deduped := make([]PortEntry, 0, len(entries))
+
+	for _, entry := range entries {
+		if seen[entry] {
+			continue
+		}
+		seen[entry] = true
+		deduped = append(deduped, entry)
+	}
+
+	return deduped
+}
+
+func splitHostPort(value string) (string, string, bool) {
+	lastColon := strings.LastIndex(value, ":")
+	if lastColon == -1 || lastColon == len(value)-1 {
+		return "", "", false
+	}
+
+	return value[:lastColon], value[lastColon+1:], true
+}
+
+func normalizeAddress(address string) string {
+	if address == "*" || address == "0.0.0.0" || address == "[::]" {
+		return "All Interfaces"
+	}
+
+	return strings.Trim(address, "[]")
 }
 
 func killProcess(pid string) error {
@@ -128,8 +241,12 @@ func getProcessDetails(pid string) (string, error) {
 		return "Process details require sudo privileges.", nil
 	}
 
-	// Run ps to get details: User, Start Time, Command
-	cmd := exec.Command("ps", "-p", pid, "-o", "user,lstart,cmd", "--no-headers")
+	var cmd *exec.Cmd
+	if runtime.GOOS == "darwin" {
+		cmd = exec.Command("ps", "-p", pid, "-o", "user=,lstart=,command=")
+	} else {
+		cmd = exec.Command("ps", "-p", pid, "-o", "user,lstart,cmd", "--no-headers")
+	}
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get details: %v", err)

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,64 @@
+package main
+
+import "testing"
+
+func TestParseSSPorts(t *testing.T) {
+	output := `Netid State  Recv-Q Send-Q Local Address:Port Peer Address:PortProcess
+tcp   LISTEN 0      4096         0.0.0.0:3000      0.0.0.0:*    users:(("node",pid=45238,fd=13))
+udp   UNCONN 0      0                  *:5353            *:*    users:(("Spotify",pid=50348,fd=704))
+`
+
+	entries := parseSSPorts(output)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Port != "3000" || entries[0].Protocol != "tcp" || entries[0].PID != "45238" {
+		t.Fatalf("unexpected tcp entry: %+v", entries[0])
+	}
+	if entries[0].Address != "All Interfaces" || entries[0].Process != "node" {
+		t.Fatalf("unexpected tcp process/address: %+v", entries[0])
+	}
+	if entries[1].Port != "5353" || entries[1].Protocol != "udp" || entries[1].PID != "50348" {
+		t.Fatalf("unexpected udp entry: %+v", entries[1])
+	}
+}
+
+func TestParseLSOFPorts(t *testing.T) {
+	output := `COMMAND     PID  USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+node      45238 pavel   13u  IPv6 0x8da4aa211495fb3d      0t0  TCP *:3000 (LISTEN)
+postgres  31485 pavel    8u  IPv6 0xf34f15ccfff19e46      0t0  TCP [::1]:5432 (LISTEN)
+Spotify   50348 pavel  704u  IPv4 0xf0ddb8fc3bb7a9a6      0t0  UDP *:5353
+Spotify   50375 pavel   32u  IPv6 0x596b91f249541c81      0t0  UDP [::1]:57007->[2600:1901:1:7c5::]:443
+identitys   955 pavel    7u  IPv4  0x26cdb681dcdd8f6      0t0  UDP *:*
+`
+
+	entries := parseLSOFPorts(output)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+	if entries[0].Port != "3000" || entries[0].Protocol != "tcp" || entries[0].Address != "All Interfaces" {
+		t.Fatalf("unexpected tcp wildcard entry: %+v", entries[0])
+	}
+	if entries[1].Port != "5432" || entries[1].Address != "::1" {
+		t.Fatalf("unexpected ipv6 entry: %+v", entries[1])
+	}
+	if entries[2].Port != "5353" || entries[2].Protocol != "udp" || entries[2].State != "UDP" {
+		t.Fatalf("unexpected udp entry: %+v", entries[2])
+	}
+}
+
+func TestDedupePorts(t *testing.T) {
+	entries := []PortEntry{
+		{Port: "3000", Protocol: "tcp", PID: "45238", Process: "node", State: "LISTEN", Address: "All Interfaces"},
+		{Port: "3000", Protocol: "tcp", PID: "45238", Process: "node", State: "LISTEN", Address: "All Interfaces"},
+		{Port: "5432", Protocol: "tcp", PID: "31485", Process: "postgres", State: "LISTEN", Address: "127.0.0.1"},
+	}
+
+	deduped := dedupePorts(entries)
+	if len(deduped) != 2 {
+		t.Fatalf("expected 2 deduped entries, got %d", len(deduped))
+	}
+	if deduped[0] != entries[0] || deduped[1] != entries[2] {
+		t.Fatalf("unexpected deduped order: %+v", deduped)
+	}
+}


### PR DESCRIPTION
I ran into the same macOS failure locally and saw that issue #1 tracks it. This PR adds a Darwin code path that uses macOS' built-in lsof instead of Linux ss, while keeping the existing ss parser for Linux.

Changes:
- use lsof for TCP listeners and UDP sockets on macOS
- keep Linux port discovery on ss -tulnp
- use a Darwin-compatible ps invocation for process details
- dedupe identical lsof rows from IPv4/IPv6 wildcard listeners
- add parser coverage for ss, lsof, and dedupe behavior
- update the README platform/prerequisite wording

Closes #1.

Tested:
- go test ./...
- go build ./...
- manual lazyports smoke test on macOS